### PR TITLE
Add --oem 0 to specify legacy model when doing OSD 

### DIFF
--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -178,7 +178,7 @@ def detect_orientation(image, lang=None):
     """
     _set_environment()
     with temp_dir() as tmpdir:
-        command = [TESSERACT_CMD, "input.bmp", 'stdout', "-psm", "0"]
+        command = [TESSERACT_CMD, "input.bmp", 'stdout', "-psm", "0", "--oem", "0"]
         if lang is not None:
             command += ['-l', lang]
 


### PR DESCRIPTION
OSD doesn't work with the new LSTM model shipped with Tesseract 4.0alpha. The old legacy model is used instead. 